### PR TITLE
Add modal G-codes display

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -285,6 +285,12 @@
     <!-- ---- Right panel: DRO + WCS + Touch-off ---- -->
     <aside id="panel-dro">
 
+      <!-- Active modal G-codes -->
+      <div class="panel-section">
+        <div class="section-title">Active Codes</div>
+        <div id="modal-codes" class="mono dim" style="font-size:0.75rem; line-height:1.6; letter-spacing:0.02em">—</div>
+      </div>
+
       <!-- Position DRO -->
       <div class="panel-section">
         <div style="display:flex; align-items:center; justify-content:space-between; margin-bottom:var(--gap-sm)">
@@ -377,5 +383,6 @@
 <script type="module" src="/static/js/gcode.js"></script>
 <script type="module" src="/static/js/viewer.js"></script>
 <script type="module" src="/static/js/guards.js"></script>
+<script type="module" src="/static/js/modal.js"></script>
 </body>
 </html>

--- a/frontend/js/modal.js
+++ b/frontend/js/modal.js
@@ -1,0 +1,29 @@
+/**
+ * modal.js — active modal G-codes strip.
+ *
+ * Renders the list of currently active modal G-codes pushed in
+ * state.modal.gcodes (list of ints where value = G-code × 10,
+ * -1 = inactive, slot 0 = sequence number).
+ */
+
+import { state, onUpdate } from "./state.js";
+
+const root = document.getElementById("modal-codes");
+
+function formatGcode(n) {
+  if (n < 0) return null;
+  const major = Math.floor(n / 10);
+  const minor = n % 10;
+  return minor ? `G${major}.${minor}` : `G${major}`;
+}
+
+function render() {
+  if (!root) return;
+  const raw = state.modal?.gcodes || [];
+  // Slot 0 is the sequence number, skip it. Drop inactive (-1) slots.
+  const codes = raw.slice(1).filter(n => n >= 0).map(formatGcode);
+  root.textContent = codes.length ? codes.join("  ") : "—";
+}
+
+onUpdate(render);
+render();

--- a/frontend/js/state.js
+++ b/frontend/js/state.js
@@ -28,6 +28,7 @@ export const state = {
   coolant:   { flood: false, mist: false },
   tool:      { number: 0, offset: [] },
   limits:    { min_soft: [], max_soft: [] },
+  modal:     { gcodes: [], mcodes: [] },
   errors:    [],
   connected: false,
 };

--- a/server/bridge.py
+++ b/server/bridge.py
@@ -227,6 +227,13 @@ class MachineBridge:
                 "min_soft": list(s.min_position_limit),
                 "max_soft": list(s.max_position_limit),
             },
+            "modal": {
+                # Raw active modal codes from LinuxCNC — list of 16 ints.
+                # Values are G-code × 10 (e.g. 170 = G17, 911 = G91.1). -1 = inactive.
+                # Slot 0 is the current sequence number, not a G-code.
+                "gcodes": list(s.gcodes) if hasattr(s, "gcodes") else [],
+                "mcodes": list(s.mcodes) if hasattr(s, "mcodes") else [],
+            },
             "errors": errors,
         }
 
@@ -319,8 +326,37 @@ class MachineBridge:
                 "min_soft": [False] * 9,
                 "max_soft": [False] * 9,
             },
+            "modal": {
+                "gcodes": self._mock_gcodes(),
+                "mcodes": [],
+            },
             "errors": [],
         }
+
+    def _mock_gcodes(self) -> list:
+        """
+        Plausible power-on modal G-code set for mock mode.
+        Values are G-code × 10 to match LinuxCNC's stat.gcodes convention.
+        Slot 0 is the sequence number (0 here); -1 = inactive slot.
+        WCS slot reflects the live g5x_index so G54→G55 switches are visible.
+        """
+        idx = self._mock["g5x_index"]
+        wcs_code = 530 + idx * 10 if idx <= 6 else 590 + (idx - 6)
+        return [
+            0,         # slot 0: sequence number
+            0,         # slot 1: motion mode — G0
+            170,       # slot 2: plane — G17 (XY)
+            900,       # slot 3: distance mode — G90 (absolute)
+            940,       # slot 4: feed mode — G94 (units/min)
+            210,       # slot 5: units — G21 (mm)
+            400,       # slot 6: cutter comp — G40 (off)
+            490,       # slot 7: tool length offset — G49 (off)
+            980,       # slot 8: canned cycle return — G98
+            wcs_code,  # slot 9: WCS — G54..G59.3
+            640,       # slot 10: path control — G64
+            970,       # slot 11: spindle mode — G97 (RPM)
+            -1, -1, -1, -1,
+        ]
 
     # ------------------------------------------------------------------
     # Command dispatch

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -419,3 +419,61 @@ class TestJogWatchdog:
         assert 1 in b._mock["jogs"]
         assert 1 not in b._client_jogs
         assert 2 in b._client_jogs
+
+
+# ---- Modal G-codes ----
+
+class TestModalGcodes:
+    def test_state_bundle_includes_modal_block(self):
+        b = MachineBridge()
+        s = _build(b)
+        assert "modal" in s
+        assert "gcodes" in s["modal"]
+        assert "mcodes" in s["modal"]
+
+    def test_mock_gcodes_length_is_16(self):
+        """LinuxCNC's stat.gcodes is always a 16-slot array."""
+        b = MachineBridge()
+        s = _build(b)
+        assert len(s["modal"]["gcodes"]) == 16
+
+    def test_mock_gcodes_defaults(self):
+        """At boot: G17 plane, G90 absolute, G94 feed/min, G21 mm, G40 no comp."""
+        b = MachineBridge()
+        g = _build(b)["modal"]["gcodes"]
+        assert 170 in g   # G17
+        assert 900 in g   # G90
+        assert 940 in g   # G94
+        assert 210 in g   # G21
+        assert 400 in g   # G40
+        assert 490 in g   # G49
+
+    def test_mock_gcodes_default_wcs_is_g54(self):
+        b = MachineBridge()
+        g = _build(b)["modal"]["gcodes"]
+        assert 540 in g
+        assert 550 not in g
+
+    def test_mock_gcodes_wcs_follows_g5x_index(self):
+        """Switching WCS via set_work_coord updates the modal G-code slot."""
+        b = MachineBridge()
+        _cmd(b, "set_work_coord", code="G55")
+        g = _build(b)["modal"]["gcodes"]
+        assert 550 in g
+        assert 540 not in g
+
+    def test_mock_gcodes_wcs_extended_registers(self):
+        """G59.1/.2/.3 (g5x_index 7/8/9) map to 591/592/593."""
+        b = MachineBridge()
+        # The set_work_coord dispatch only maps G54-G59, so poke g5x_index directly
+        # to verify _mock_gcodes handles the extended range correctly.
+        b._mock["g5x_index"] = 7
+        assert 591 in _build(b)["modal"]["gcodes"]
+        b._mock["g5x_index"] = 9
+        assert 593 in _build(b)["modal"]["gcodes"]
+
+    def test_mock_gcodes_inactive_slots_are_negative(self):
+        """Trailing slots should be -1 (inactive) per LinuxCNC convention."""
+        b = MachineBridge()
+        g = _build(b)["modal"]["gcodes"]
+        assert g[-1] == -1


### PR DESCRIPTION
## Summary

Closes #5.

First HMI shake-down feature from the sprint backlog. Displays currently active modal G-codes (motion, plane, distance, feed mode, units, cutter comp, tool length offset, WCS, path control, spindle mode) as a read-only strip above the DRO panel.

## What changed

**Backend** ([server/bridge.py](server/bridge.py))
- State bundle now includes a `modal` block with `gcodes` and `mcodes` lists
- Real mode forwards `stat.gcodes` / `stat.mcodes` verbatim (16-slot int array, value = G-code × 10, -1 = inactive)
- Mock mode: new `_mock_gcodes()` returns a plausible power-on set. WCS slot follows `g5x_index` so G54→G55 switches show live

**Frontend**
- [state.js](frontend/js/state.js) initialises `state.modal` for subscribers
- New [modal.js](frontend/js/modal.js) formats ints into G-code strings (170 → G17, 911 → G91.1) and updates the strip on each state frame
- [index.html](frontend/index.html): new **Active Codes** section at the top of the DRO aside — placed there so it can be relocated cleanly when the persistent-DRO structural work lands later

**Tests**
- 7 new unit tests for `modal` block shape, default codes, and WCS tracking
- Full suite: 88/88 passing

## Test plan

- [x] `docker compose restart webui` picks up backend change cleanly
- [x] UI loads with an **Active Codes** section at the top of the right panel
- [x] Strip shows `G0  G17  G90  G94  G21  G40  G49  G98  G54  G64  G97` (or similar) on first connect in mock mode
- [x] Switching WCS (click G54 → G55 in right panel) updates the strip's WCS code live
- [x] Running a G-code program does not break the strip (still renders codes on each state frame)
- [x] No console errors in browser devtools
- [x] No layout regression on other tabs (MDI, Auto, Offsets, Status)
- [x] `pytest tests/test_bridge.py::TestModalGcodes -v` passes (7 tests)

## Out of scope

- Clicking a code to change mode (display only)
- Relocation into a persistent DRO panel (covered by future structural issue)
- Tooltips with code descriptions (nice-to-have follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)