### PR TITLE
Fix auto-tab restoration on refresh during running program

### DIFF
--- a/frontend/js/guards.js
+++ b/frontend/js/guards.js
@@ -233,7 +233,12 @@ onUpdate((s) => {
   _applyGates(s);
   _statusHint(s);
 
-  if (_justConnected && s.connected) {
+  // Wait for a real state frame (populated pos.actual) before deciding whether
+  // to auto-switch to Auto. state.js fires handlers on WS connect BEFORE the
+  // first frame arrives, at which point s.machine is still the default
+  // (mode=MANUAL, interp=IDLE) and the condition never matches.
+  const hasRealState = Array.isArray(s.pos?.actual) && s.pos.actual.length > 0;
+  if (_justConnected && s.connected && hasRealState) {
     _justConnected = false;
     const mode   = s.machine?.mode ?? MODE_MANUAL;
     const interp = s.machine?.interp_state ?? INTERP_IDLE;


### PR DESCRIPTION
## Summary

Closes #12.

One-line timing fix in [guards.js](frontend/js/guards.js). \`_justConnected\` was being cleared on the very first \`onUpdate\` call — which fires from [state.js](frontend/js/state.js) the moment WS connects, *before* any real state frame arrives. At that point \`s.machine\` was still the default (\`mode=MANUAL, interp=IDLE\`), so the Auto-switch condition never matched and subsequent real-state frames didn't re-check.

Added a \`hasRealState\` guard (check \`s.pos.actual.length > 0\`) so the flag is only consumed once we have actual machine state to inspect.

## Test plan

- [x] Start a program running, refresh the browser → lands on Auto tab showing the running job
- [x] Pause a program, refresh → lands on Auto tab showing the paused state
- [x] Idle machine with no program, refresh → stays on Manual (default) — no unwanted jump to Auto
- [x] Manual tab switches (clicking MDI, Offsets etc.) still work normally — not affected
- [x] \`pytest tests/\` — all 88 still pass (no backend change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)