### PR TITLE
Mock bridge: simulate tool changes and spindle speed

### DIFF
--- a/server/bridge.py
+++ b/server/bridge.py
@@ -23,17 +23,32 @@ except ImportError:
 log = logging.getLogger(__name__)
 
 
-def _parse_waypoints(path: str):
-    """Parse a G-code file and return (waypoints, waypoint_lines).
+def _parse_program(path: str):
+    """Parse a G-code file and return a dict with waypoints + tool/spindle events.
 
-    waypoints  — list of (line_num, x, y, z) in WCS mm, sorted by line_num
-    waypoint_lines — list of just the line numbers (for bisect lookups)
+    Returns:
+        waypoints       — list of (line_num, x, y, z) in WCS mm
+        waypoint_lines  — [line_num, ...] parallel list for bisect
+        tool_events     — list of (line_num, tool_number) for every M6 tool change
+        tool_lines      — parallel bisect list
+        spindle_events  — list of (line_num, speed, direction) where direction
+                          is +1 for M3 (CW), -1 for M4 (CCW), 0 for M5 (stop).
+                          speed carries the last-seen S word; 0 after M5.
+        spindle_lines   — parallel bisect list
     """
-    waypoints = []
+    waypoints      = []
+    tool_events    = []
+    spindle_events = []
     x, y, z = 0.0, 0.0, 0.0
     abs_mode = True
     scale    = 1.0
     motion   = 0
+    # T word latches; M6 consumes the latched tool. Bare M6 with no prior T
+    # falls back to the last-seen T (standard LinuxCNC behaviour).
+    pending_tool = None
+    last_tool    = 0
+    # Current commanded spindle speed from S words. M3/M4 apply it; M5 zeros.
+    current_s = 0.0
     try:
         with open(path) as f:
             for line_num, raw in enumerate(f, 1):
@@ -49,6 +64,30 @@ def _parse_waypoints(path: str):
                     if g == 91: abs_mode = False
                     if g == 20: scale = 25.4
                     if g == 21: scale = 1.0
+                # T word — latch for next M6
+                if 'T' in words:
+                    pending_tool = int(words['T'])
+                # S word — update current commanded speed (affects the next M3/M4)
+                if 'S' in words:
+                    current_s = float(words['S'])
+                # M-codes: multiple M words can appear on one line so scan the
+                # raw text rather than the dedup'd dict.
+                m_codes = [int(round(float(m.group(1))))
+                           for m in _re.finditer(r'M\s*(\d+)', line)]
+                if 6 in m_codes:
+                    tool = pending_tool if pending_tool is not None else last_tool
+                    tool_events.append((line_num, tool))
+                    last_tool    = tool
+                    pending_tool = None
+                if 3 in m_codes:
+                    spindle_events.append((line_num, current_s, 1))
+                if 4 in m_codes:
+                    spindle_events.append((line_num, current_s, -1))
+                if 5 in m_codes:
+                    spindle_events.append((line_num, 0.0, 0))
+                # M30 / M2 — program end implies M5
+                if 30 in m_codes or 2 in m_codes:
+                    spindle_events.append((line_num, 0.0, 0))
                 if not any(k in words for k in ('X', 'Y', 'Z')):
                     continue
                 if abs_mode:
@@ -61,9 +100,15 @@ def _parse_waypoints(path: str):
                     if 'Z' in words: z += words['Z'] * scale
                 waypoints.append((line_num, x, y, z))
     except Exception as e:
-        log.warning(f"Could not parse waypoints from {path}: {e}")
-    lines = [w[0] for w in waypoints]
-    return waypoints, lines
+        log.warning(f"Could not parse program {path}: {e}")
+    return {
+        "waypoints":      waypoints,
+        "waypoint_lines": [w[0] for w in waypoints],
+        "tool_events":    tool_events,
+        "tool_lines":     [t[0] for t in tool_events],
+        "spindle_events": spindle_events,
+        "spindle_lines":  [s[0] for s in spindle_events],
+    }
 
 
 class MachineBridge:
@@ -106,6 +151,24 @@ class MachineBridge:
             # Parsed waypoints for position simulation
             "program_waypoints":     [],    # [(line_num, x, y, z), ...] WCS mm
             "program_waypoint_lines":[],    # [line_num, ...] parallel list for bisect
+            # Parsed tool changes — (line_num, tool_number). Bisect at the
+            # current program line to find the active tool during run.
+            "program_tool_events":   [],
+            "program_tool_lines":    [],
+            # Parsed spindle events — (line_num, speed, direction). Direction:
+            # +1 M3 CW, -1 M4 CCW, 0 M5/end-of-program.
+            "program_spindle_events": [],
+            "program_spindle_lines":  [],
+            # Current mock tool state — persists across programs the way a
+            # real tool stays in the spindle after M30.
+            "tool_number": 0,
+            # Current mock spindle state — set by program events or MDI ops.
+            "spindle_speed":     0.0,
+            "spindle_direction": 0,
+            "spindle_enabled":   False,
+            # time.time() when commanded spindle state last changed; used to
+            # simulate the ~500ms ramp-up before at_speed flips true.
+            "spindle_changed_at": 0.0,
         }
 
     # ------------------------------------------------------------------
@@ -267,6 +330,13 @@ class MachineBridge:
                     m["program_running"] = False
                     m["program_paused"]  = False
                     m["mode"]            = 1  # back to MANUAL when done
+                    # Implicit M5 at natural program end (safety net for NGC
+                    # files without an explicit M30/M2).
+                    if m["spindle_enabled"]:
+                        m["spindle_speed"]      = 0.0
+                        m["spindle_direction"]  = 0
+                        m["spindle_enabled"]    = False
+                        m["spindle_changed_at"] = now
 
         # Move simulated tool position along the parsed waypoints
         if m["program_running"] or m["program_paused"]:
@@ -280,6 +350,31 @@ class MachineBridge:
                     pos = [wx + off[0], wy + off[1], wz + off[2]] + [0.0] * 6
                     m["pos"] = pos
 
+            # Resolve active tool from parsed M6 events up to current line
+            t_lns = m["program_tool_lines"]
+            if t_lns:
+                ti = bisect.bisect_right(t_lns, m["program_line"]) - 1
+                if ti >= 0:
+                    new_tool = m["program_tool_events"][ti][1]
+                    if new_tool != m["tool_number"]:
+                        m["tool_number"] = new_tool
+
+            # Resolve active spindle state from parsed M3/M4/M5 events
+            s_lns = m["program_spindle_lines"]
+            if s_lns:
+                si = bisect.bisect_right(s_lns, m["program_line"]) - 1
+                if si >= 0:
+                    _, speed, direction = m["program_spindle_events"][si]
+                    signed = speed * direction
+                    # Only bump the "changed at" timestamp when the commanded
+                    # state actually changes — keeps at_speed stable across frames.
+                    if (signed != m["spindle_speed"]
+                            or direction != m["spindle_direction"]):
+                        m["spindle_speed"]      = signed
+                        m["spindle_direction"]  = direction
+                        m["spindle_enabled"]    = direction != 0
+                        m["spindle_changed_at"] = now
+
         # interp_state: 1=IDLE 2=READING 3=PAUSED
         if m["program_running"] and not m["program_paused"]:
             interp_state = 2
@@ -287,6 +382,10 @@ class MachineBridge:
             interp_state = 3
         else:
             interp_state = 1
+
+        # at_speed: stable commanded speed for >= 500ms while enabled.
+        at_speed = (m["spindle_enabled"]
+                    and (now - m["spindle_changed_at"]) >= 0.5)
 
         return {
             "pos": {
@@ -316,12 +415,16 @@ class MachineBridge:
             },
             "overrides": {"feed": m["feed_override"], "rapid": m["rapid_override"]},
             "spindle": [{
-                "speed": 0.0, "direction": 0, "enabled": False,
-                "at_speed": False, "override": m["spindle_override"],
-                "override_enabled": True, "brake": False,
+                "speed":             m["spindle_speed"],
+                "direction":         m["spindle_direction"],
+                "enabled":           m["spindle_enabled"],
+                "at_speed":          at_speed,
+                "override":          m["spindle_override"],
+                "override_enabled":  True,
+                "brake":             False,
             }],
             "coolant": {"flood": m["flood"], "mist": m["mist"]},
-            "tool": {"number": 0, "offset": [0.0] * 9},
+            "tool": {"number": m["tool_number"], "offset": [0.0] * 9},
             "limits": {
                 "min_soft": [False] * 9,
                 "max_soft": [False] * 9,
@@ -457,6 +560,22 @@ class MachineBridge:
         elif op == "spindle_override":
             m["spindle_override"] = max(0.0, float(msg.get("value", 1.0)))
 
+        elif op == "spindle_on":
+            # MDI-driven spindle start. Assume CW unless explicitly reversed.
+            speed     = float(msg.get("speed", 0.0))
+            direction = int(msg.get("direction", 1)) or 1
+            signed    = speed * (1 if direction > 0 else -1)
+            m["spindle_speed"]      = signed
+            m["spindle_direction"]  = 1 if direction > 0 else -1
+            m["spindle_enabled"]    = True
+            m["spindle_changed_at"] = time.time()
+
+        elif op == "spindle_off":
+            m["spindle_speed"]      = 0.0
+            m["spindle_direction"]  = 0
+            m["spindle_enabled"]    = False
+            m["spindle_changed_at"] = time.time()
+
         elif op == "flood_on":  m["flood"] = True
         elif op == "flood_off": m["flood"] = False
         elif op == "mist_on":   m["mist"]  = True
@@ -497,10 +616,14 @@ class MachineBridge:
             m["program_running"] = False
             m["program_paused"]  = False
             m["mode"]            = 1
-            # Parse waypoints and count lines
-            wp, wp_lns = _parse_waypoints(path)
-            m["program_waypoints"]      = wp
-            m["program_waypoint_lines"] = wp_lns
+            # Parse waypoints + tool/spindle events
+            parsed = _parse_program(path)
+            m["program_waypoints"]       = parsed["waypoints"]
+            m["program_waypoint_lines"]  = parsed["waypoint_lines"]
+            m["program_tool_events"]     = parsed["tool_events"]
+            m["program_tool_lines"]      = parsed["tool_lines"]
+            m["program_spindle_events"]  = parsed["spindle_events"]
+            m["program_spindle_lines"]   = parsed["spindle_lines"]
             try:
                 with open(path) as _f:
                     m["program_total_lines"] = sum(1 for _ in _f)
@@ -538,6 +661,11 @@ class MachineBridge:
             m["program_paused"]  = False
             m["program_line"]    = 0
             m["mode"]            = 1  # MANUAL
+            # Spindle stops on program stop (implicit M5); tool stays loaded.
+            m["spindle_speed"]      = 0.0
+            m["spindle_direction"]  = 0
+            m["spindle_enabled"]    = False
+            m["spindle_changed_at"] = time.time()
 
         # All other mock commands are acknowledged but ignored
         return {"ok": True, "mock": True}

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "server"))
-from bridge import MachineBridge
+from bridge import MachineBridge, _parse_program
 
 
 # ---- Helpers ----
@@ -477,3 +477,195 @@ class TestModalGcodes:
         b = MachineBridge()
         g = _build(b)["modal"]["gcodes"]
         assert g[-1] == -1
+
+
+# ---- Program parser: tool and spindle events ----
+
+def _write_ngc(tmp_path, body):
+    p = tmp_path / "test.ngc"
+    p.write_text(body)
+    return str(p)
+
+
+class TestParseProgramToolEvents:
+    def test_t_then_m6_captures_tool_change(self, tmp_path):
+        path = _write_ngc(tmp_path, "N10 T3 M6\nN20 G0 X0\n")
+        parsed = _parse_program(path)
+        assert parsed["tool_events"] == [(1, 3)]
+
+    def test_bare_m6_uses_previous_t(self, tmp_path):
+        path = _write_ngc(tmp_path, "N10 T2 M6\nN20 M6\n")
+        parsed = _parse_program(path)
+        assert parsed["tool_events"] == [(1, 2), (2, 2)]
+
+    def test_multiple_tool_changes(self, tmp_path):
+        path = _write_ngc(tmp_path, "T1 M6\nG0 X5\nT2 M6\nG0 X10\n")
+        parsed = _parse_program(path)
+        assert parsed["tool_events"] == [(1, 1), (3, 2)]
+
+    def test_t_without_m6_is_not_a_change(self, tmp_path):
+        path = _write_ngc(tmp_path, "T1\nG0 X0\n")
+        parsed = _parse_program(path)
+        assert parsed["tool_events"] == []
+
+    def test_comments_are_stripped(self, tmp_path):
+        path = _write_ngc(tmp_path, "(T99 M6 in a comment)\nT1 M6\n")
+        parsed = _parse_program(path)
+        assert parsed["tool_events"] == [(2, 1)]
+
+
+class TestParseProgramSpindleEvents:
+    def test_s_then_m3_starts_cw(self, tmp_path):
+        path = _write_ngc(tmp_path, "S5000 M3\nG0 X0\n")
+        parsed = _parse_program(path)
+        assert parsed["spindle_events"] == [(1, 5000.0, 1)]
+
+    def test_m4_is_ccw(self, tmp_path):
+        path = _write_ngc(tmp_path, "S3000 M4\n")
+        parsed = _parse_program(path)
+        assert parsed["spindle_events"] == [(1, 3000.0, -1)]
+
+    def test_m5_stops(self, tmp_path):
+        path = _write_ngc(tmp_path, "S4000 M3\nG0 X5\nM5\n")
+        parsed = _parse_program(path)
+        assert parsed["spindle_events"] == [(1, 4000.0, 1), (3, 0.0, 0)]
+
+    def test_m30_implies_m5(self, tmp_path):
+        path = _write_ngc(tmp_path, "S2000 M3\nG0 X1\nM30\n")
+        parsed = _parse_program(path)
+        assert (3, 0.0, 0) in parsed["spindle_events"]
+
+    def test_speed_change_mid_program(self, tmp_path):
+        path = _write_ngc(tmp_path, "S1000 M3\nS2000\nM3\n")
+        parsed = _parse_program(path)
+        # Line 3's M3 re-applies with the updated S word.
+        assert (3, 2000.0, 1) in parsed["spindle_events"]
+
+
+# ---- Program run: tool and spindle resolve from events ----
+
+class TestProgramRunResolvesToolAndSpindle:
+    def _ready(self, tmp_path, body):
+        b = MachineBridge()
+        _cmd(b, "estop_reset")
+        _cmd(b, "machine_on")
+        _cmd(b, "home_all")
+        path = _write_ngc(tmp_path, body)
+        _cmd(b, "program_open", path=path)
+        _cmd(b, "program_run")
+        return b
+
+    def test_before_m6_tool_is_zero(self, tmp_path):
+        b = self._ready(tmp_path, "G0 X0\nT1 M6\nG0 X5\n")
+        # Force line=0 (before M6 at line 2) — running state, but parser hasn't
+        # reached the tool change yet.
+        b._mock["program_line"] = 0
+        assert _build(b)["tool"]["number"] == 0
+
+    def test_after_m6_tool_updates(self, tmp_path):
+        b = self._ready(tmp_path, "G0 X0\nT1 M6\nG0 X5\n")
+        b._mock["program_line"] = 2
+        assert _build(b)["tool"]["number"] == 1
+
+    def test_second_tool_change_overrides(self, tmp_path):
+        b = self._ready(tmp_path, "T1 M6\nG0 X1\nT2 M6\nG0 X2\n")
+        b._mock["program_line"] = 3
+        assert _build(b)["tool"]["number"] == 2
+
+    def test_m3_sets_spindle_running_cw(self, tmp_path):
+        b = self._ready(tmp_path, "S4000 M3\nG0 X0\n")
+        b._mock["program_line"] = 1
+        s = _build(b)["spindle"][0]
+        assert s["enabled"] is True
+        assert s["speed"] == 4000.0
+        assert s["direction"] == 1
+
+    def test_m4_sets_spindle_ccw_negative_speed(self, tmp_path):
+        b = self._ready(tmp_path, "S3000 M4\n")
+        b._mock["program_line"] = 1
+        s = _build(b)["spindle"][0]
+        assert s["direction"] == -1
+        assert s["speed"] == -3000.0
+
+    def test_m5_stops_spindle(self, tmp_path):
+        b = self._ready(tmp_path, "S5000 M3\nG0 X1\nM5\n")
+        b._mock["program_line"] = 3
+        s = _build(b)["spindle"][0]
+        assert s["enabled"] is False
+        assert s["speed"] == 0.0
+
+    def test_tool_persists_after_program_stop(self, tmp_path):
+        b = self._ready(tmp_path, "T7 M6\nG0 X1\n")
+        b._mock["program_line"] = 1
+        _build(b)   # resolve tool=7 while running
+        _cmd(b, "program_stop")
+        # After stop, tool stays loaded (realistic) but spindle is off.
+        assert _build(b)["tool"]["number"] == 7
+        assert _build(b)["spindle"][0]["enabled"] is False
+
+
+# ---- at_speed debounce ----
+
+class TestAtSpeed:
+    def _ready(self):
+        b = MachineBridge()
+        _cmd(b, "estop_reset")
+        _cmd(b, "machine_on")
+        _cmd(b, "home_all")
+        return b
+
+    def test_at_speed_false_immediately_after_spindle_on(self):
+        b = self._ready()
+        _cmd(b, "spindle_on", speed=2000)
+        s = _build(b)["spindle"][0]
+        assert s["enabled"] is True
+        assert s["at_speed"] is False
+
+    def test_at_speed_true_after_ramp(self):
+        b = self._ready()
+        _cmd(b, "spindle_on", speed=2000)
+        # Simulate ramp-up by backdating the change timestamp.
+        b._mock["spindle_changed_at"] -= 1.0
+        assert _build(b)["spindle"][0]["at_speed"] is True
+
+    def test_at_speed_resets_when_spindle_off(self):
+        b = self._ready()
+        _cmd(b, "spindle_on", speed=2000)
+        b._mock["spindle_changed_at"] -= 1.0
+        assert _build(b)["spindle"][0]["at_speed"] is True
+        _cmd(b, "spindle_off")
+        assert _build(b)["spindle"][0]["at_speed"] is False
+
+
+# ---- MDI spindle ops update mock state ----
+
+class TestSpindleMdiOps:
+    def _ready(self):
+        b = MachineBridge()
+        _cmd(b, "estop_reset")
+        _cmd(b, "machine_on")
+        return b
+
+    def test_spindle_on_cw(self):
+        b = self._ready()
+        _cmd(b, "spindle_on", speed=1500, direction=1)
+        s = _build(b)["spindle"][0]
+        assert s["enabled"] is True
+        assert s["direction"] == 1
+        assert s["speed"] == 1500.0
+
+    def test_spindle_on_ccw(self):
+        b = self._ready()
+        _cmd(b, "spindle_on", speed=1500, direction=-1)
+        s = _build(b)["spindle"][0]
+        assert s["direction"] == -1
+        assert s["speed"] == -1500.0
+
+    def test_spindle_off_clears(self):
+        b = self._ready()
+        _cmd(b, "spindle_on", speed=2000)
+        _cmd(b, "spindle_off")
+        s = _build(b)["spindle"][0]
+        assert s["enabled"] is False
+        assert s["speed"] == 0.0
+        assert s["direction"] == 0

--- a/webui_plan.md
+++ b/webui_plan.md
@@ -233,6 +233,7 @@ Get the data flowing and commands working. UI can be ugly.
 - [x] G10 L20 touch-off correctly computes WCS offsets
 - [x] WCS switching (G54–G59) via `set_work_coord`
 - [x] Jog integration with axis velocity simulation
+- [x] Tool changes (T/M6) and spindle commands (S/M3/M4/M5) resolved during program run; at_speed debounce simulates ramp-up
 - [x] Note: real machine uses `stat()` at 20 Hz — pos.actual interpolates smoothly between waypoints automatically
 
 ---


### PR DESCRIPTION
## Summary

- Mock G-code parser now extracts T/M6 tool changes and S/M3/M4/M5 spindle events alongside waypoints
- During program run, \`_mock_state\` bisects events against the current line to resolve active tool + spindle state
- MDI \`spindle_on\`/\`spindle_off\` ops update mock state (previously silently dropped)
- \`at_speed\` debounces 500ms after state change — simulates real-spindle ramp-up
- Program stop / natural end triggers implicit M5; tool number persists (realistic)

Unblocks end-to-end demo of PR #21's strip indicators in mock mode. Refs #14.

## Scope boundary

Tool-table **Z offset** simulation is still out of scope (mock returns zeros). Per issue #14 this is called out as a separate concern, and it's not load-bearing for collet workflows where operators touch off Z manually at every tool change. Leave #14 open until the tool-table tab lands and Z offsets become real.

## Test plan

- [x] 111 unit tests pass (23 new covering parser + run-time resolution + at_speed + MDI spindle ops)
- [x] Load medal_hanger.ngc in mock browser: before run, RPM 0 / Tool 0 as before
- [x] Press Run: at line 8 tool display transitions 0 → 1, at line 9 RPM transitions 0 → 5000
- [x] PR #21's CW arrow appears on the strip (blue) once M3 resolves
- [x] At-speed dot transitions dim → green ~500ms after M3 (hard to see with the 3 lines/sec advance, but observable if paused just after M3)
- [x] Press Stop: spindle returns to RPM 0, arrow/dot hide, tool stays loaded (e.g. T1)
- [x] Open MDI tab, press Spindle CW button: strip shows ↻ arrow, RPM matches commanded
- [x] Press Spindle Stop: arrow/dot hide, RPM 0
- [x] Load a program with M4 somewhere: CCW arrow (amber) appears when reached
- [x] Load a program with mid-program S-word change: RPM updates at the line where new M3/M4 re-applies it

🤖 Generated with [Claude Code](https://claude.com/claude-code)