### PR TITLE
Mock MDI: execute motion / spindle / tool / coolant / WCS G-code

### DIFF
--- a/server/bridge.py
+++ b/server/bridge.py
@@ -111,6 +111,101 @@ def _parse_program(path: str):
     }
 
 
+def _apply_mdi_line(m: dict, gcode: str) -> bool:
+    """Execute a single MDI G-code line against the mock machine state.
+
+    Handles a pragmatic subset — enough to demo tool changes, spindle ops,
+    coolant, and motion from the MDI tab without loading a program. Unknown
+    input is silently accepted (returns False).
+
+    Returns True if the line matched a known pattern and the mock state
+    was mutated.
+    """
+    line = _re.sub(r'\(.*?\)', '', gcode).split(';')[0].strip().upper()
+    if not line:
+        return False
+
+    words    = {mm.group(1): float(mm.group(2))
+                for mm in _re.finditer(r'([A-Z])\s*(-?\d*\.?\d+)', line)}
+    m_codes  = [int(round(float(mm.group(1))))
+                for mm in _re.finditer(r'M\s*(\d+)', line)]
+    # Collect ALL G words on this line — the words-dict above loses earlier
+    # ones when multiple appear (e.g. "G90 G0 X10").
+    g_codes  = [float(mm.group(1))
+                for mm in _re.finditer(r'G\s*(\d+(?:\.\d+)?)', line)]
+
+    # G53: single-line modifier — motion uses machine coords, no WCS offset.
+    use_machine_coords = any(abs(g - 53.0) < 0.01 for g in g_codes)
+
+    # Persistent modals (G90/G91/G20/G21)
+    for g in g_codes:
+        if g == 90:  m["mdi_abs_mode"] = True
+        if g == 91:  m["mdi_abs_mode"] = False
+        if g == 20:  m["mdi_scale"] = 25.4
+        if g == 21:  m["mdi_scale"] = 1.0
+
+    # WCS selection — G54…G59.3 map to g5x_index 1…9.
+    wcs_map = {54.0: 1, 55.0: 2, 56.0: 3, 57.0: 4, 58.0: 5, 59.0: 6,
+               59.1: 7, 59.2: 8, 59.3: 9}
+    for g in g_codes:
+        if g in wcs_map:
+            m["g5x_index"] = wcs_map[g]
+
+    if 'T' in words:
+        m["mdi_pending_tool"] = int(words['T'])
+    if 'S' in words:
+        m["mdi_current_s"] = float(words['S'])
+
+    now = time.time()
+    if 6 in m_codes:
+        tool = m["mdi_pending_tool"] if m["mdi_pending_tool"] is not None else m["tool_number"]
+        m["tool_number"]      = tool
+        m["mdi_pending_tool"] = None
+    if 3 in m_codes:
+        m["spindle_speed"]      = m["mdi_current_s"]
+        m["spindle_direction"]  = 1
+        m["spindle_enabled"]    = True
+        m["spindle_changed_at"] = now
+    if 4 in m_codes:
+        m["spindle_speed"]      = -m["mdi_current_s"]
+        m["spindle_direction"]  = -1
+        m["spindle_enabled"]    = True
+        m["spindle_changed_at"] = now
+    if 5 in m_codes:
+        m["spindle_speed"]      = 0.0
+        m["spindle_direction"]  = 0
+        m["spindle_enabled"]    = False
+        m["spindle_changed_at"] = now
+    if 7 in m_codes:
+        m["mist"] = True
+    if 8 in m_codes:
+        m["flood"] = True
+    if 9 in m_codes:
+        m["mist"]  = False
+        m["flood"] = False
+
+    # Motion — G0/G1 with any X/Y/Z word. Mock treats moves as instant.
+    axis_map = {'X': 0, 'Y': 1, 'Z': 2}
+    has_xyz    = any(k in words for k in axis_map)
+    has_motion = any(g in (0.0, 1.0) for g in g_codes)
+    if has_xyz and has_motion:
+        new_pos = list(m["pos"])
+        for ax_name, ax_idx in axis_map.items():
+            if ax_name not in words:
+                continue
+            val = words[ax_name] * m["mdi_scale"]
+            if use_machine_coords:
+                new_pos[ax_idx] = val
+            elif m["mdi_abs_mode"]:
+                off = m["g5x_offsets"][m["g5x_index"]][ax_idx]
+                new_pos[ax_idx] = val + off
+            else:
+                new_pos[ax_idx] += val
+        m["pos"] = new_pos
+
+    return True
+
+
 class MachineBridge:
     def __init__(self):
         self._stat = None
@@ -169,6 +264,13 @@ class MachineBridge:
             # time.time() when commanded spindle state last changed; used to
             # simulate the ~500ms ramp-up before at_speed flips true.
             "spindle_changed_at": 0.0,
+            # MDI session modals — persist across MDI lines (LinuxCNC behaviour).
+            # G90/G91 → abs_mode; G20/G21 → scale. G54–G59.3 modals live in
+            # g5x_index. T word latches here until M6 consumes it.
+            "mdi_abs_mode":     True,
+            "mdi_scale":        1.0,
+            "mdi_pending_tool": None,
+            "mdi_current_s":    0.0,
         }
 
     # ------------------------------------------------------------------
@@ -606,6 +708,9 @@ class MachineBridge:
                         ai = axis_map.get(am.group(1), -1)
                         if ai >= 0:
                             m["g5x_offsets"][p][ai] = pos[ai] - float(am.group(2))
+            else:
+                # Motion / spindle / tool / coolant / WCS execution in mock.
+                _apply_mdi_line(m, gcode)
 
         elif op == "program_open":
             if m.get("program_running"):

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "server"))
-from bridge import MachineBridge, _parse_program
+from bridge import MachineBridge, _parse_program, _apply_mdi_line
 
 
 # ---- Helpers ----
@@ -669,3 +669,196 @@ class TestSpindleMdiOps:
         assert s["enabled"] is False
         assert s["speed"] == 0.0
         assert s["direction"] == 0
+
+
+# ---- MDI G-code execution in mock ----
+
+class TestMdiMotion:
+    def _ready(self):
+        b = MachineBridge()
+        _cmd(b, "estop_reset")
+        _cmd(b, "machine_on")
+        _cmd(b, "home_all")
+        return b
+
+    def test_g0_absolute_updates_position(self):
+        b = self._ready()
+        _cmd(b, "mdi", gcode="G0 X10 Y20")
+        s = _build(b)
+        assert s["pos"]["actual"][0] == pytest.approx(10.0)
+        assert s["pos"]["actual"][1] == pytest.approx(20.0)
+
+    def test_g1_absolute_updates_position(self):
+        b = self._ready()
+        _cmd(b, "mdi", gcode="G1 Z-5 F100")
+        assert _build(b)["pos"]["actual"][2] == pytest.approx(-5.0)
+
+    def test_g91_incremental_accumulates(self):
+        b = self._ready()
+        _cmd(b, "mdi", gcode="G91")
+        _cmd(b, "mdi", gcode="G1 X5")
+        _cmd(b, "mdi", gcode="G1 X3")
+        assert _build(b)["pos"]["actual"][0] == pytest.approx(8.0)
+
+    def test_g90_after_g91_switches_back_to_absolute(self):
+        b = self._ready()
+        _cmd(b, "mdi", gcode="G91")
+        _cmd(b, "mdi", gcode="G1 X5")   # pos = 5
+        _cmd(b, "mdi", gcode="G90")
+        _cmd(b, "mdi", gcode="G0 X2")   # should go to 2, not 7
+        assert _build(b)["pos"]["actual"][0] == pytest.approx(2.0)
+
+    def test_g90_g0_xy_combined_on_one_line(self):
+        b = self._ready()
+        _cmd(b, "mdi", gcode="G91")       # switch to incremental first
+        _cmd(b, "mdi", gcode="G90 G0 X10 Y15")  # one-liner resets to abs + moves
+        s = _build(b)["pos"]["actual"]
+        assert s[0] == pytest.approx(10.0)
+        assert s[1] == pytest.approx(15.0)
+
+    def test_motion_in_wcs_applies_offset(self):
+        b = self._ready()
+        # Poke a G55 offset: work zero is at machine (100, 50).
+        b._mock["g5x_offsets"][2] = [100.0, 50.0, 0.0, 0, 0, 0, 0, 0, 0]
+        _cmd(b, "mdi", gcode="G55")
+        _cmd(b, "mdi", gcode="G0 X0 Y0")
+        s = _build(b)["pos"]["actual"]
+        assert s[0] == pytest.approx(100.0)
+        assert s[1] == pytest.approx(50.0)
+
+    def test_g53_bypasses_wcs_offset(self):
+        b = self._ready()
+        b._mock["g5x_offsets"][1] = [100.0, 50.0, 0.0, 0, 0, 0, 0, 0, 0]
+        _cmd(b, "mdi", gcode="G53 G0 Z0")
+        assert _build(b)["pos"]["actual"][2] == pytest.approx(0.0)
+
+    def test_g20_imperial_scales_input(self):
+        b = self._ready()
+        _cmd(b, "mdi", gcode="G20")       # switch to inches
+        _cmd(b, "mdi", gcode="G0 X1")     # 1 inch = 25.4 mm
+        assert _build(b)["pos"]["actual"][0] == pytest.approx(25.4)
+
+
+class TestMdiSpindle:
+    def _ready(self):
+        b = MachineBridge()
+        _cmd(b, "estop_reset")
+        _cmd(b, "machine_on")
+        return b
+
+    def test_m3_starts_cw(self):
+        b = self._ready()
+        _cmd(b, "mdi", gcode="M3 S4000")
+        s = _build(b)["spindle"][0]
+        assert s["enabled"] is True
+        assert s["direction"] == 1
+        assert s["speed"] == 4000.0
+
+    def test_m4_starts_ccw(self):
+        b = self._ready()
+        _cmd(b, "mdi", gcode="S3000 M4")
+        s = _build(b)["spindle"][0]
+        assert s["direction"] == -1
+        assert s["speed"] == -3000.0
+
+    def test_m5_stops(self):
+        b = self._ready()
+        _cmd(b, "mdi", gcode="M3 S4000")
+        _cmd(b, "mdi", gcode="M5")
+        s = _build(b)["spindle"][0]
+        assert s["enabled"] is False
+        assert s["speed"] == 0.0
+
+    def test_s_word_alone_then_m3_later(self):
+        b = self._ready()
+        _cmd(b, "mdi", gcode="S5000")     # latches pending speed
+        _cmd(b, "mdi", gcode="M3")        # applies it
+        assert _build(b)["spindle"][0]["speed"] == 5000.0
+
+
+class TestMdiTool:
+    def _ready(self):
+        b = MachineBridge()
+        _cmd(b, "estop_reset")
+        _cmd(b, "machine_on")
+        return b
+
+    def test_m6_tn_changes_tool(self):
+        b = self._ready()
+        _cmd(b, "mdi", gcode="T3 M6")
+        assert _build(b)["tool"]["number"] == 3
+
+    def test_t_without_m6_does_not_change_tool(self):
+        b = self._ready()
+        _cmd(b, "mdi", gcode="T5")
+        assert _build(b)["tool"]["number"] == 0
+
+    def test_bare_m6_uses_last_latched_t(self):
+        b = self._ready()
+        _cmd(b, "mdi", gcode="T7")   # latch
+        _cmd(b, "mdi", gcode="M6")   # consume
+        assert _build(b)["tool"]["number"] == 7
+
+
+class TestMdiCoolant:
+    def _ready(self):
+        b = MachineBridge()
+        _cmd(b, "estop_reset")
+        _cmd(b, "machine_on")
+        return b
+
+    def test_m8_enables_flood(self):
+        b = self._ready()
+        _cmd(b, "mdi", gcode="M8")
+        assert _build(b)["coolant"]["flood"] is True
+
+    def test_m7_enables_mist(self):
+        b = self._ready()
+        _cmd(b, "mdi", gcode="M7")
+        assert _build(b)["coolant"]["mist"] is True
+
+    def test_m9_clears_both(self):
+        b = self._ready()
+        _cmd(b, "mdi", gcode="M8")
+        _cmd(b, "mdi", gcode="M7")
+        _cmd(b, "mdi", gcode="M9")
+        c = _build(b)["coolant"]
+        assert c["flood"] is False
+        assert c["mist"]  is False
+
+
+class TestMdiWcs:
+    def _ready(self):
+        b = MachineBridge()
+        _cmd(b, "estop_reset")
+        _cmd(b, "machine_on")
+        return b
+
+    def test_g55_switches_wcs(self):
+        b = self._ready()
+        _cmd(b, "mdi", gcode="G55")
+        assert _build(b)["pos"]["g5x_index"] == 2
+
+    def test_g59_3_switches_wcs(self):
+        b = self._ready()
+        _cmd(b, "mdi", gcode="G59.3")
+        assert _build(b)["pos"]["g5x_index"] == 9
+
+
+class TestMdiTouchOffRegression:
+    """G10 L20 touch-off must still work after the MDI-execution path was added."""
+
+    def _ready(self):
+        b = MachineBridge()
+        _cmd(b, "estop_reset")
+        _cmd(b, "machine_on")
+        _cmd(b, "home_all")
+        return b
+
+    def test_touch_off_still_sets_wcs_offset(self):
+        b = self._ready()
+        # Move to machine (20, 0, 0) first, then declare "this is X=5 in G54".
+        _cmd(b, "mdi", gcode="G0 X20")
+        _cmd(b, "mdi", gcode="G10 L20 P1 X5")
+        # Offset should now be 20 - 5 = 15
+        assert b._mock["g5x_offsets"][1][0] == pytest.approx(15.0)

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -726,11 +726,20 @@ class TestMdiMotion:
         assert s[0] == pytest.approx(100.0)
         assert s[1] == pytest.approx(50.0)
 
-    def test_g53_bypasses_wcs_offset(self):
+    def test_g53_moves_in_machine_coords(self):
         b = self._ready()
-        b._mock["g5x_offsets"][1] = [100.0, 50.0, 0.0, 0, 0, 0, 0, 0, 0]
+        # G54 work zero is at machine (100, 50, 10). Without G53 a "G0 Z0"
+        # would land at machine Z=10. With G53 it must land at machine Z=0.
+        b._mock["g5x_offsets"][1] = [100.0, 50.0, 10.0, 0, 0, 0, 0, 0, 0]
         _cmd(b, "mdi", gcode="G53 G0 Z0")
         assert _build(b)["pos"]["actual"][2] == pytest.approx(0.0)
+
+    def test_non_g53_move_respects_wcs_offset(self):
+        """Sanity: the strengthened G53 test needs its WCS counterpart."""
+        b = self._ready()
+        b._mock["g5x_offsets"][1] = [100.0, 50.0, 10.0, 0, 0, 0, 0, 0, 0]
+        _cmd(b, "mdi", gcode="G0 Z0")   # no G53 → WCS-relative
+        assert _build(b)["pos"]["actual"][2] == pytest.approx(10.0)
 
     def test_g20_imperial_scales_input(self):
         b = self._ready()


### PR DESCRIPTION
## Summary

Previously the mock \`mdi\` handler only recognised \`G10 L20\` touch-off. Every other command was silently dropped — MDI was useless for demoing tool changes, spindle start, or retract macros without loading a program.

New \`_apply_mdi_line(m, gcode)\` handles:

- **Motion**: \`G0\`/\`G1\` with X/Y/Z (instant, no timing simulation)
- **G53 modifier**: single-line bypass of WCS offset
- **Persistent modals**: \`G90\`/\`G91\` (abs/incremental), \`G20\`/\`G21\` (imperial/metric) — persist across MDI lines as LinuxCNC does
- **WCS**: \`G54\`–\`G59.3\` switch \`g5x_index\`
- **Spindle**: S latches, \`M3\`/\`M4\`/\`M5\` apply with direction (reuses PR #22 state fields)
- **Tool**: T latches, \`M6\` consumes (bare \`M6\` uses last-latched T)
- **Coolant**: \`M7\` mist / \`M8\` flood / \`M9\` clears both

Existing \`G10 L20\` touch-off path preserved (regression test added).

Closes #23. Paves the way for #18 safety-layer work where mock-tested pre-amble / retract / park macros are load-bearing.

## Scope boundary

Out of scope per issue #23: arc interpolation (G2/G3), cutter comp (G41/G42), feed-rate timing, O-words / subroutines. Multi-G lines like \`G90 G0 X10\` are handled (bugfix along the way — scans all G words on the line instead of dict-overwriting).

## Test plan

- [x] 132 unit tests pass (21 new across motion / G53 / modals / imperial / spindle / tool / coolant / WCS / touch-off regression)
- [x] Browser: MDI \`G0 X10 Y20\` → strip DRO updates to 10.000 / 20.000
- [x] Browser: MDI \`M3 S4000\` → strip ↻ arrow appears, RPM shows 4000, at-speed dot transitions dim → green after ~500ms
- [x] Browser: MDI \`M5\` → arrow/dot hide, RPM returns to 0
- [x] Browser: MDI \`T3 M6\` → strip tool field shows 3
- [x] Browser: MDI \`G55\` → strip WCS badge flips to G55
- [x] Browser: MDI \`G53 G0 Z0\` → machine Z goes to 0 regardless of WCS offset
- [x] Browser: MDI \`G91\` then two \`G1 X5\` → X accumulates to 10 (incremental persists)
- [x] Browser: Zero-All touch-off button still works (regression — goes through \`G10 L20\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)