### PR TITLE
MDI history persistence + viewer trail clear

### DIFF
--- a/frontend/css/components.css
+++ b/frontend/css/components.css
@@ -220,6 +220,18 @@ input[type="range"]::-moz-range-thumb {
 
 .mdi-input:focus { border-color: var(--accent); }
 
+/* MDI history entries — clickable to copy back into the input. */
+.mdi-history-entry {
+  color: var(--text-primary);
+  cursor: pointer;
+  padding: 0 var(--gap-sm);
+  border-radius: var(--radius);
+}
+.mdi-history-entry:hover {
+  background: var(--bg-3);
+  color: var(--accent);
+}
+
 /* ---- Status bar (bottom of screen) ---- */
 #status-bar {
   padding: 0.25rem var(--gap-lg);

--- a/frontend/css/components.css
+++ b/frontend/css/components.css
@@ -232,6 +232,19 @@ input[type="range"]::-moz-range-thumb {
   color: var(--accent);
 }
 
+/* MDI history header row — section title + Clear button. */
+.mdi-history-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--gap-sm);
+  margin-bottom: var(--gap-sm);
+}
+.mdi-history-clear {
+  font-size: 0.65rem;
+  padding: 0.2rem 0.55rem;
+}
+
 /* ---- Status bar (bottom of screen) ---- */
 #status-bar {
   padding: 0.25rem var(--gap-lg);

--- a/frontend/css/components.css
+++ b/frontend/css/components.css
@@ -226,10 +226,16 @@ input[type="range"]::-moz-range-thumb {
   cursor: pointer;
   padding: 0 var(--gap-sm);
   border-radius: var(--radius);
+  border-left: 2px solid transparent;   /* reserves space so .selected doesn't shift layout */
 }
 .mdi-history-entry:hover {
   background: var(--bg-3);
   color: var(--accent);
+}
+.mdi-history-entry.selected {
+  background: var(--bg-3);
+  color: var(--accent);
+  border-left-color: var(--accent);
 }
 
 /* MDI history header row — section title + Clear button. */

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -165,6 +165,8 @@
             <button class="btn btn-default viewer-plane-btn" data-plane="3D" title="3D orbit view — drag to rotate, shift+drag to pan">3D</button>
           </div>
           <button class="btn btn-default" id="btn-viewer-fit" title="Fit to content">⊡ Fit</button>
+          <button class="btn btn-default" id="btn-viewer-clear-trail"
+                  title="Clear motion trail — safe any time, never affects the machine">⌫ Trail</button>
           <div class="viewer-sep"></div>
           <span class="viewer-pos-display">
             <span class="viewer-axis-label" style="color:var(--dro-x)">X</span>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -192,7 +192,11 @@
           <button class="btn btn-primary" id="btn-mdi-send">Send</button>
         </div>
         <div style="flex:1; overflow-y:auto; padding:var(--gap-sm) var(--gap); border-top:1px solid var(--border)">
-          <div class="section-title">History</div>
+          <div class="mdi-history-header">
+            <span class="section-title">History</span>
+            <button class="btn btn-default mdi-history-clear" id="btn-mdi-history-clear"
+                    title="Clear MDI history — safe to press at any time, including during a run">Clear</button>
+          </div>
           <div id="mdi-history" style="font-family:var(--font-mono); font-size:0.75rem; line-height:1.6"></div>
         </div>
       </div>

--- a/frontend/js/guards.js
+++ b/frontend/js/guards.js
@@ -33,13 +33,14 @@ const INTERP_PAUSED  = 3;
 
 // Buttons that must never be gated — UI navigation and safety controls.
 const NEVER_GATE = [
-  ".tab-btn",          // tab switching
-  ".viewer-plane-btn", // XY / XZ / YZ view selector
-  ".strip-mode-btn",   // strip WCS / ABS display mode — read-only, never affects machine
-  "#btn-estop",        // always reachable (safety)
-  "#btn-prog-open",    // file selection is harmless
-  "#btn-browse",       // file selection is harmless
-  "#btn-viewer-fit",   // camera control
+  ".tab-btn",                 // tab switching
+  ".viewer-plane-btn",        // XY / XZ / YZ view selector
+  ".strip-mode-btn",          // strip WCS / ABS display mode — read-only, never affects machine
+  "#btn-estop",               // always reachable (safety)
+  "#btn-prog-open",           // file selection is harmless
+  "#btn-browse",               // file selection is harmless
+  "#btn-viewer-fit",          // camera control
+  "#btn-mdi-history-clear",   // client-side display clear — never affects machine
 ].join(", ");
 
 // ---- Helpers ----
@@ -83,7 +84,8 @@ function _updateEstopBtn(s) {
 function _reEnableNav() {
   // Split into individual selectors to avoid :not() list compatibility issues
   [".tab-btn", ".viewer-plane-btn", ".strip-mode-btn",
-   "#btn-estop", "#btn-prog-open", "#btn-browse", "#btn-viewer-fit"].forEach(sel => {
+   "#btn-estop", "#btn-prog-open", "#btn-browse", "#btn-viewer-fit",
+   "#btn-mdi-history-clear"].forEach(sel => {
     document.querySelectorAll(sel).forEach(el => { el.disabled = false; el.title = ""; });
   });
 }

--- a/frontend/js/guards.js
+++ b/frontend/js/guards.js
@@ -39,8 +39,9 @@ const NEVER_GATE = [
   "#btn-estop",               // always reachable (safety)
   "#btn-prog-open",           // file selection is harmless
   "#btn-browse",               // file selection is harmless
-  "#btn-viewer-fit",          // camera control
-  "#btn-mdi-history-clear",   // client-side display clear — never affects machine
+  "#btn-viewer-fit",             // camera control
+  "#btn-viewer-clear-trail",     // clears live motion trail only — never affects machine
+  "#btn-mdi-history-clear",      // client-side display clear — never affects machine
 ].join(", ");
 
 // ---- Helpers ----
@@ -85,7 +86,7 @@ function _reEnableNav() {
   // Split into individual selectors to avoid :not() list compatibility issues
   [".tab-btn", ".viewer-plane-btn", ".strip-mode-btn",
    "#btn-estop", "#btn-prog-open", "#btn-browse", "#btn-viewer-fit",
-   "#btn-mdi-history-clear"].forEach(sel => {
+   "#btn-viewer-clear-trail", "#btn-mdi-history-clear"].forEach(sel => {
     document.querySelectorAll(sel).forEach(el => { el.disabled = false; el.title = ""; });
   });
 }

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -101,6 +101,21 @@ mdiInput?.addEventListener("keydown", (e) => {
   if (e.key === "Enter") _sendMDI();
 });
 
+// Clear button — wipes the visible panel, the in-memory array, and storage.
+// Safe to press at any time including during a run (clears display only,
+// never affects the machine).
+const mdiClearBtn = document.getElementById("btn-mdi-history-clear");
+if (mdiClearBtn) {
+  mdiClearBtn.addEventListener("click", () => {
+    mdiHistory_.length = 0;
+    if (mdiHistory) mdiHistory.innerHTML = "";
+    try { localStorage.removeItem(MDI_HISTORY_KEY); } catch {}
+    _histIdx = -1;
+  });
+  // Never gated by machine state — pure display action.
+  mdiClearBtn.disabled = false;
+}
+
 // MDI history navigation (up/down arrows)
 let _histIdx = -1;
 mdiInput?.addEventListener("keydown", (e) => {

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -36,21 +36,63 @@ document.getElementById("btn-unhome-all")?.addEventListener("click", () => {
 
 const mdiInput   = document.getElementById("mdi-input");
 const mdiHistory = document.getElementById("mdi-history");
-const mdiHistory_ = [];
+const MDI_HISTORY_KEY   = "webui:mdiHistory";
+const MDI_HISTORY_LIMIT = 100;
+
+function _loadHistory() {
+  try {
+    const raw = localStorage.getItem(MDI_HISTORY_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter(v => typeof v === "string") : [];
+  } catch {
+    return [];   // private mode, quota, or malformed JSON
+  }
+}
+
+function _saveHistory() {
+  try {
+    localStorage.setItem(MDI_HISTORY_KEY, JSON.stringify(mdiHistory_));
+  } catch {
+    // Storage disabled/full — history still works in-memory for this session.
+  }
+}
+
+const mdiHistory_ = _loadHistory();
+
+function _appendHistoryLine(gcode) {
+  if (!mdiHistory) return;
+  const line = document.createElement("div");
+  line.className   = "mdi-history-entry";
+  line.textContent = `> ${gcode}`;
+  line.title       = "Click to copy to input";
+  line.addEventListener("click", () => {
+    mdiInput.value = gcode;
+    mdiInput.focus();
+    // Place cursor at end so the operator can edit immediately.
+    const n = mdiInput.value.length;
+    mdiInput.setSelectionRange(n, n);
+    _histIdx = -1;   // break out of arrow-key navigation
+  });
+  mdiHistory.appendChild(line);
+  mdiHistory.scrollTop = mdiHistory.scrollHeight;
+}
+
+// Re-hydrate visible panel from loaded history
+mdiHistory_.forEach(_appendHistoryLine);
 
 function _sendMDI() {
   const gcode = mdiInput.value.trim();
   if (!gcode) return;
   send({ cmd: "mdi", gcode });
   mdiHistory_.push(gcode);
-  if (mdiHistory_.length > 100) mdiHistory_.shift();
-  if (mdiHistory) {
-    const line = document.createElement("div");
-    line.textContent = `> ${gcode}`;
-    line.style.color = "var(--text-primary)";
-    mdiHistory.appendChild(line);
-    mdiHistory.scrollTop = mdiHistory.scrollHeight;
+  if (mdiHistory_.length > MDI_HISTORY_LIMIT) {
+    mdiHistory_.shift();
+    // Drop the oldest DOM entry to stay in sync with the array.
+    mdiHistory?.firstElementChild?.remove();
   }
+  _appendHistoryLine(gcode);
+  _saveHistory();
   mdiInput.value = "";
 }
 

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -124,6 +124,12 @@ mdiInput?.addEventListener("keydown", (e) => {
 const mdiClearBtn = document.getElementById("btn-mdi-history-clear");
 if (mdiClearBtn) {
   mdiClearBtn.addEventListener("click", () => {
+    if (mdiHistory_.length === 0) return;   // nothing to clear — no prompt
+    const n = mdiHistory_.length;
+    if (!window.confirm(
+      `Clear all ${n} MDI history ${n === 1 ? "entry" : "entries"}?\n\n` +
+      `This cannot be undone.`
+    )) return;
     mdiHistory_.length = 0;
     if (mdiHistory) mdiHistory.innerHTML = "";
     try { localStorage.removeItem(MDI_HISTORY_KEY); } catch {}

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -73,9 +73,24 @@ function _appendHistoryLine(gcode) {
     const n = mdiInput.value.length;
     mdiInput.setSelectionRange(n, n);
     _histIdx = -1;   // break out of arrow-key navigation
+    _highlightHistory();
   });
   mdiHistory.appendChild(line);
   mdiHistory.scrollTop = mdiHistory.scrollHeight;
+}
+
+// Visually mark the history entry matching _histIdx (arrow-key navigation).
+// DOM children are 1:1 with mdiHistory_ (newest last); _histIdx=0 is newest.
+function _highlightHistory() {
+  if (!mdiHistory) return;
+  const children = mdiHistory.children;
+  const target   = _histIdx < 0 ? -1 : children.length - 1 - _histIdx;
+  for (let i = 0; i < children.length; i++) {
+    children[i].classList.toggle("selected", i === target);
+  }
+  if (target >= 0) {
+    children[target].scrollIntoView({ block: "nearest" });
+  }
 }
 
 // Re-hydrate visible panel from loaded history
@@ -94,6 +109,8 @@ function _sendMDI() {
   _appendHistoryLine(gcode);
   _saveHistory();
   mdiInput.value = "";
+  _histIdx = -1;
+  _highlightHistory();
 }
 
 document.getElementById("btn-mdi-send")?.addEventListener("click", _sendMDI);
@@ -111,6 +128,7 @@ if (mdiClearBtn) {
     if (mdiHistory) mdiHistory.innerHTML = "";
     try { localStorage.removeItem(MDI_HISTORY_KEY); } catch {}
     _histIdx = -1;
+    _highlightHistory();
   });
   // Never gated by machine state — pure display action.
   mdiClearBtn.disabled = false;
@@ -123,12 +141,16 @@ mdiInput?.addEventListener("keydown", (e) => {
     e.preventDefault();
     _histIdx = Math.min(_histIdx + 1, mdiHistory_.length - 1);
     mdiInput.value = mdiHistory_[mdiHistory_.length - 1 - _histIdx] ?? "";
+    _highlightHistory();
   } else if (e.key === "ArrowDown") {
     e.preventDefault();
     _histIdx = Math.max(_histIdx - 1, -1);
     mdiInput.value = _histIdx === -1 ? "" : (mdiHistory_[mdiHistory_.length - 1 - _histIdx] ?? "");
-  } else {
+    _highlightHistory();
+  } else if (e.key !== "Enter") {
+    // Any other key (user is typing) breaks out of navigation.
     _histIdx = -1;
+    _highlightHistory();
   }
 });
 

--- a/frontend/js/viewer.js
+++ b/frontend/js/viewer.js
@@ -21,7 +21,8 @@ const canvas   = document.getElementById("viewer-canvas");
 const vposX    = document.getElementById("vpos-x");
 const vposY    = document.getElementById("vpos-y");
 const vposZ    = document.getElementById("vpos-z");
-const fitBtn   = document.getElementById("btn-viewer-fit");
+const fitBtn        = document.getElementById("btn-viewer-fit");
+const clearTrailBtn = document.getElementById("btn-viewer-clear-trail");
 const statusEl = document.getElementById("viewer-status");
 
 if (!canvas) throw new Error("viewer-canvas not found");
@@ -856,6 +857,13 @@ document.querySelectorAll(".viewer-plane-btn").forEach(btn => {
 
 fitBtn?.addEventListener("click", () => {
   _fitToContent();
+  _scheduleRender();
+});
+
+// Clear motion trail — wipes _toolTrail only. Does NOT affect the loaded
+// toolpath render or machine state. Safe any time, including during a run.
+clearTrailBtn?.addEventListener("click", () => {
+  _toolTrail = [];
   _scheduleRender();
 });
 


### PR DESCRIPTION
## Summary

**MDI history (closes #26):**
- Persists across page refreshes via `localStorage` (keyed `webui:mdiHistory`, capped at 100 entries)
- History entries are clickable → copies command back into the input (no auto-send), cursor at end
- Up/Down arrow navigation highlights the matching entry (left border + accent tint) and scrolls it into view
- **Clear** button with confirmation prompt showing entry count (skipped when already empty)
- Graceful fallback when `localStorage` is unavailable (private mode, quota)

**Viewer motion trail:**
- New **⌫ Trail** button in the viewer toolbar — clears `_toolTrail` (the fading motion-history overlay) on demand
- Distinct from MDI Clear because they target different state: MDI Clear wipes the command list, Trail Clear wipes the live-motion overlay that accumulates while monitoring a program

Both Clear buttons are pure client-side display actions — added to `guards.js` `NEVER_GATE` so they stay clickable at any time including during a program run, in AUTO mode, and when disconnected.

## Test plan

- [x] Type a couple of MDI commands, refresh the page → history still shown
- [x] Click a history entry → text appears in input, focus in input, cursor at end, **not** auto-sent
- [x] Edit the copied text, press Enter → new command sends correctly, old clicked entry remains in history
- [x] Hover a history entry → pointer cursor and subtle background tint
- [x] Up/Down arrows walk through history in the input AND highlight the matching history entry (left border + accent colour)
- [x] Highlight scrolls into view when the target entry is outside the visible panel
- [x] Highlight clears when user types (not Enter/arrow), sends a command, clicks an entry, or hits Clear
- [x] Send 101+ commands → history caps at 100, oldest drops from both storage and visible panel
- [x] Private/incognito window → history works in-memory, no console errors when localStorage blocked
- [x] Click MDI Clear with entries present → confirm dialog shows correct count → Cancel leaves history intact → OK wipes everything and refresh shows empty
- [x] Click MDI Clear with empty history → no prompt shown (no-op)
- [x] Both Clear buttons are clickable during a program run (AUTO mode) and while disconnected
- [x] Load and run a program → motion trail builds up in the viewer → click ⌫ Trail → trail vanishes, loaded toolpath render + crosshair remain
- [x] Full test suite passes (133/133)

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)