### PR TITLE
Fix: touch-off per-axis Zero buttons clipped off-screen

### DIFF
--- a/frontend/js/dro.js
+++ b/frontend/js/dro.js
@@ -99,7 +99,10 @@ function _buildTouchOff(axes) {
     inp.type = "number";
     inp.value = "0";
     inp.step = "0.001";
-    inp.style.cssText = "flex:1; font-family:var(--font-mono); font-size:0.8rem; padding:0.3rem 0.5rem; background:var(--bg-3); border:1px solid var(--border-hi); border-radius:var(--radius); color:var(--text-primary); outline:none";
+    // min-width:0 lets flexbox shrink the input below its ~150px browser
+    // default; otherwise the sibling Zero button gets pushed off the right
+    // edge of a narrow aside.
+    inp.style.cssText = "flex:1; min-width:0; font-family:var(--font-mono); font-size:0.8rem; padding:0.3rem 0.5rem; background:var(--bg-3); border:1px solid var(--border-hi); border-radius:var(--radius); color:var(--text-primary); outline:none";
     inp.id = `touch-off-${i}`;
     inp.title = `Target value for ${axisName} after zero (default 0 = "this position is zero").\nChange only if you need a specific reference other than zero.`;
     // No live tracking — the DRO rows above already show the live position.
@@ -108,6 +111,7 @@ function _buildTouchOff(axes) {
     const btn = document.createElement("button");
     btn.className = "btn btn-warn";
     btn.textContent = "Zero";
+    btn.style.flexShrink = "0";   // defensive — never let the Zero button shrink out of view
     btn.dataset.axis = i;
     btn.dataset.axisName = axisName;
     btn.addEventListener("click", () => {


### PR DESCRIPTION
## Summary

Two one-liners in \`_buildTouchOff\` to fix per-axis Zero buttons being pushed off the right edge of the narrow right-hand aside:

- \`min-width: 0\` on the number input — lets flexbox shrink it below its ~150px browser default
- \`flex-shrink: 0\` on the Zero button — defensive guarantee it never disappears

Shane confirmed via DevTools that the buttons existed in the DOM but weren't visible on screen.

Closes #30

## Test plan

- [x] Each axis row (X, Y, Z) shows a visible \`Zero\` button to the right of its input
- [x] Z-row Zero sends \`G10 L20 P{n} Z{value}\` (only Z, not X/Y)
- [x] "Zero All Axes" still works
- [x] Narrow the browser to 1024 px wide — buttons still visible, inputs scale down, no horizontal overflow
- [x] Full test suite passes (133/133, JS-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)