### PR TITLE
Viewer: fade executed + envelope-aware fit + Reset button + splitter

### DIFF
--- a/frontend/css/layout.css
+++ b/frontend/css/layout.css
@@ -123,6 +123,22 @@
   display: none;
 }
 
+/* Horizontal splitter between viewer and tab panels below. Thin strip with
+   a row-resize cursor; hides automatically when the viewer is hidden. */
+#viewer-splitter {
+  flex: 0 0 6px;
+  background: var(--bg-2);
+  border-top:    1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  cursor: row-resize;
+  user-select: none;
+  touch-action: none;
+  transition: background 120ms;
+}
+#viewer-splitter:hover,
+#viewer-splitter.dragging { background: var(--accent-dim); }
+#shared-viewer.hidden + #viewer-splitter { display: none; }
+
 /* ---- Per-tab control strips / full panels ---- */
 .tab-panel {
   display: none;                /* hidden by default */

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -165,6 +165,8 @@
             <button class="btn btn-default viewer-plane-btn" data-plane="3D" title="3D orbit view — drag to rotate, shift+drag to pan">3D</button>
           </div>
           <button class="btn btn-default" id="btn-viewer-fit" title="Fit to content">⊡ Fit</button>
+          <button class="btn btn-default" id="btn-viewer-reset"
+                  title="Reset 3D view — default orbit angle + fit">↺ Reset</button>
           <button class="btn btn-default" id="btn-viewer-clear-trail"
                   title="Clear motion trail — safe any time, never affects the machine">⌫ Trail</button>
           <div class="viewer-sep"></div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -185,6 +185,11 @@
         <canvas id="viewer-canvas"></canvas>
       </div>
 
+      <!-- Draggable splitter between the viewer and whatever tab panel sits
+           below it (gcode listing, MDI history, auto-controls). Hidden
+           automatically when the viewer is hidden via the CSS sibling rule. -->
+      <div id="viewer-splitter" title="Drag to resize — double-click to reset"></div>
+
       <!-- ══════════════════════════════════════════════════════════
            MDI control strip
            Shown below the viewer when MDI tab is active.

--- a/frontend/js/guards.js
+++ b/frontend/js/guards.js
@@ -40,6 +40,7 @@ const NEVER_GATE = [
   "#btn-prog-open",           // file selection is harmless
   "#btn-browse",               // file selection is harmless
   "#btn-viewer-fit",             // camera control
+  "#btn-viewer-reset",           // camera control — default orbit + fit
   "#btn-viewer-clear-trail",     // clears live motion trail only — never affects machine
   "#btn-mdi-history-clear",      // client-side display clear — never affects machine
 ].join(", ");
@@ -86,7 +87,8 @@ function _reEnableNav() {
   // Split into individual selectors to avoid :not() list compatibility issues
   [".tab-btn", ".viewer-plane-btn", ".strip-mode-btn",
    "#btn-estop", "#btn-prog-open", "#btn-browse", "#btn-viewer-fit",
-   "#btn-viewer-clear-trail", "#btn-mdi-history-clear"].forEach(sel => {
+   "#btn-viewer-reset", "#btn-viewer-clear-trail",
+   "#btn-mdi-history-clear"].forEach(sel => {
     document.querySelectorAll(sel).forEach(el => { el.disabled = false; el.title = ""; });
   });
 }

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -225,3 +225,76 @@ onUpdate((s) => {
     });
   }
 });
+
+// ---- Viewer / panel-below splitter ----
+// Lets the operator resize the toolpath viewer vs the gcode listing / MDI
+// history / auto controls below it. Persists the chosen height in
+// localStorage. Double-click returns to the default flex ratio.
+
+const VIEWER_HEIGHT_KEY = "webui:viewerHeightPx";
+const splitter      = document.getElementById("viewer-splitter");
+const sharedViewer  = document.getElementById("shared-viewer");
+const panelMain     = document.getElementById("panel-main");
+
+function _applyViewerHeight(px) {
+  if (!sharedViewer) return;
+  // flex:0 0 {px}px pins the viewer to this height; the panel below fills
+  // whatever space remains. Clamped by min-height in the CSS.
+  sharedViewer.style.flex = `0 0 ${px}px`;
+}
+
+function _resetViewerHeight() {
+  if (!sharedViewer) return;
+  sharedViewer.style.flex = "";   // revert to stylesheet default (3 1 0)
+  try { localStorage.removeItem(VIEWER_HEIGHT_KEY); } catch {}
+}
+
+// Restore any previously saved height on load.
+try {
+  const saved = localStorage.getItem(VIEWER_HEIGHT_KEY);
+  if (saved) {
+    const px = parseInt(saved, 10);
+    if (Number.isFinite(px) && px > 0) _applyViewerHeight(px);
+  }
+} catch {}
+
+if (splitter && sharedViewer && panelMain) {
+  let dragging = false;
+
+  splitter.addEventListener("pointerdown", (e) => {
+    dragging = true;
+    splitter.setPointerCapture(e.pointerId);
+    splitter.classList.add("dragging");
+    e.preventDefault();
+  });
+
+  splitter.addEventListener("pointermove", (e) => {
+    if (!dragging) return;
+    // New viewer height = mouse Y relative to the top of panel-main, minus
+    // the tab-bar height (which sits above #shared-viewer inside panel-main).
+    const rect   = panelMain.getBoundingClientRect();
+    const tabBar = document.getElementById("tab-bar");
+    const tabBarH = tabBar ? tabBar.getBoundingClientRect().height : 0;
+    // Respect the panel-main bottom so the panel below doesn't collapse to
+    // zero; reserve 6rem (~96px) of minimum space for it.
+    const maxH = rect.height - tabBarH - 96;
+    const rawH = e.clientY - rect.top - tabBarH;
+    const h    = Math.max(96, Math.min(maxH, rawH));
+    _applyViewerHeight(h);
+  });
+
+  const _endDrag = (e) => {
+    if (!dragging) return;
+    dragging = false;
+    splitter.classList.remove("dragging");
+    splitter.releasePointerCapture?.(e.pointerId);
+    // Persist final height.
+    const h = sharedViewer.getBoundingClientRect().height;
+    try { localStorage.setItem(VIEWER_HEIGHT_KEY, String(Math.round(h))); } catch {}
+  };
+  splitter.addEventListener("pointerup",     _endDrag);
+  splitter.addEventListener("pointercancel", _endDrag);
+
+  // Double-click → reset to stylesheet default flex ratio.
+  splitter.addEventListener("dblclick", _resetViewerHeight);
+}

--- a/frontend/js/viewer.js
+++ b/frontend/js/viewer.js
@@ -22,7 +22,12 @@ const vposX    = document.getElementById("vpos-x");
 const vposY    = document.getElementById("vpos-y");
 const vposZ    = document.getElementById("vpos-z");
 const fitBtn        = document.getElementById("btn-viewer-fit");
+const resetBtn      = document.getElementById("btn-viewer-reset");
 const clearTrailBtn = document.getElementById("btn-viewer-clear-trail");
+
+// Default orbit: looking from the front-right, camera tilted 45° down.
+// Matches the "isometric-ish" orientation most CAM tools use by default.
+const DEFAULT_ROT3D = { az: -30, el: 45 };
 const statusEl = document.getElementById("viewer-status");
 
 if (!canvas) throw new Error("viewer-canvas not found");
@@ -79,7 +84,7 @@ let _cam = { cx: 0, cy: 0, cz: 0, scale: 5 };
 
 // 3D orbit rotation (degrees).  azimuth rotates around Z (turntable);
 // elevation tilts the view up/down.  Clamped to [-89, 89] for elevation.
-let _rot3d = { az: -30, el: 25 };
+let _rot3d = { ...DEFAULT_ROT3D };
 
 // ---- Plane helpers (2D modes) ----
 
@@ -998,6 +1003,17 @@ document.querySelectorAll(".viewer-plane-btn").forEach(btn => {
 // ---- Fit button ----
 
 fitBtn?.addEventListener("click", () => {
+  _fitToContent();
+  _scheduleRender();
+});
+
+// Reset — restore the default orbit angle AND fit. Use when the camera
+// has been rotated into a disorienting position (e.g. upside-down) and
+// you want to get back to a known-good view in one click.
+resetBtn?.addEventListener("click", () => {
+  _rot3d.az = DEFAULT_ROT3D.az;
+  _rot3d.el = DEFAULT_ROT3D.el;
+  _offscreenCam = null;   // force re-render under new orientation
   _fitToContent();
   _scheduleRender();
 });

--- a/frontend/js/viewer.js
+++ b/frontend/js/viewer.js
@@ -60,6 +60,13 @@ let _bounds   = null;   // machine limits {X:[min,max], Y:[min,max], Z:[min,max]
 let _toolPos   = [0, 0, 0];  // machine coordinates (for viewer crosshair drawing)
 let _toolTrail = [];         // recent tool positions [[x,y,z], …] newest at end
 const TRAIL_MAX = 80;        // ~4 s of history at 20 Hz
+
+// Executed-segment fade: segments whose line is within this many lines
+// behind _execLine render at full opacity; older segments fade linearly
+// toward EXECUTED_FADE_FLOOR. Emphasises the current cut without hiding
+// the full-path context. Ref #28.
+const EXECUTED_FADE_WINDOW = 100;
+const EXECUTED_FADE_FLOOR  = 0.18;
 let _wcsOffset = [0, 0, 0];  // g5x + g92 offset — adds to WCS to get machine coordinates
 let _execLine = 0;           // program line currently executed (0 = nothing running)
 let _offscreen    = null;
@@ -353,6 +360,15 @@ function _feedColour(z, minZ, range) {
 
 // ---- Offscreen render (2D planes) ----
 
+// Alpha for an executed segment N lines behind the current execution line.
+// Linear decay across EXECUTED_FADE_WINDOW, clamped to EXECUTED_FADE_FLOOR.
+function _executedAlpha(segLine, exec) {
+  const dist = exec - segLine;
+  if (dist <= 0) return 1.0;
+  const t = dist / EXECUTED_FADE_WINDOW;
+  return Math.max(EXECUTED_FADE_FLOOR, 1.0 - t * (1.0 - EXECUTED_FADE_FLOOR));
+}
+
 function _renderOffscreen2D(oc) {
   const oct = oc.getContext("2d");
   const { minZ, range } = _zRange();
@@ -388,18 +404,38 @@ function _renderOffscreen2D(oc) {
     oct.beginPath(); oct.moveTo(p0.x, p0.y); oct.lineTo(p1.x, p1.y); oct.stroke();
   }
 
-  // --- Executed feed segments — green "cut" trail ---
+  // --- Executed feed segments — green "cut" trail, fading with age ---
+  // Two passes: older-than-window batched at floor alpha (one stroke),
+  // recent segments per-stroke with fading alpha. Caps per-segment stroke
+  // count at EXECUTED_FADE_WINDOW regardless of program length.
   if (exec > 0) {
-    oct.lineWidth = 1.5;
+    oct.save();
+    oct.lineWidth   = 1.5;
     oct.strokeStyle = C.cut;
+    const fadeStart = exec - EXECUTED_FADE_WINDOW;
+
+    // Batch pass: everything older than the fade window at floor alpha.
+    oct.globalAlpha = EXECUTED_FADE_FLOOR;
     oct.beginPath();
     for (const s of _segments) {
-      if (s.type !== "feed" || s.line > exec) continue;
+      if (s.type !== "feed" || s.line > exec || s.line >= fadeStart) continue;
       const [u0, v0] = _uv(mpt(s.from)), [u1, v1] = _uv(mpt(s.to));
       const p0 = _w2c(u0, v0), p1 = _w2c(u1, v1);
       oct.moveTo(p0.x, p0.y); oct.lineTo(p1.x, p1.y);
     }
     oct.stroke();
+
+    // Recent pass: per-segment alpha.
+    for (const s of _segments) {
+      if (s.type !== "feed" || s.line > exec || s.line < fadeStart) continue;
+      oct.globalAlpha = _executedAlpha(s.line, exec);
+      const [u0, v0] = _uv(mpt(s.from)), [u1, v1] = _uv(mpt(s.to));
+      const p0 = _w2c(u0, v0), p1 = _w2c(u1, v1);
+      oct.beginPath();
+      oct.moveTo(p0.x, p0.y); oct.lineTo(p1.x, p1.y);
+      oct.stroke();
+    }
+    oct.restore();
   }
 }
 
@@ -443,16 +479,32 @@ function _renderOffscreen3D(oc) {
     oct.beginPath(); oct.moveTo(s.p0.sx, s.p0.sy); oct.lineTo(s.p1.sx, s.p1.sy); oct.stroke();
   }
 
-  // --- Executed feeds — green cut trail ---
+  // --- Executed feeds — green cut trail, fading with age ---
+  // Same two-pass scheme as 2D renderer for bounded stroke count.
   if (exec > 0) {
-    oct.lineWidth = 1.5;
+    oct.save();
+    oct.lineWidth   = 1.5;
     oct.strokeStyle = C.cut;
+    const fadeStart = exec - EXECUTED_FADE_WINDOW;
+
+    // Batch pass: older-than-window at floor alpha.
+    oct.globalAlpha = EXECUTED_FADE_FLOOR;
     oct.beginPath();
     for (const s of proj) {
-      if (s.type !== "feed" || s.line > exec) continue;
+      if (s.type !== "feed" || s.line > exec || s.line >= fadeStart) continue;
       oct.moveTo(s.p0.sx, s.p0.sy); oct.lineTo(s.p1.sx, s.p1.sy);
     }
     oct.stroke();
+
+    // Recent pass: per-segment fade.
+    for (const s of proj) {
+      if (s.type !== "feed" || s.line > exec || s.line < fadeStart) continue;
+      oct.globalAlpha = _executedAlpha(s.line, exec);
+      oct.beginPath();
+      oct.moveTo(s.p0.sx, s.p0.sy); oct.lineTo(s.p1.sx, s.p1.sy);
+      oct.stroke();
+    }
+    oct.restore();
   }
 }
 

--- a/frontend/js/viewer.js
+++ b/frontend/js/viewer.js
@@ -185,6 +185,16 @@ function _fitTo3D() {
     mnZ = _bounds?.Z[0] ?? -200; mxZ = _bounds?.Z[1] ?? 0;
   }
 
+  // Expand the XY fit to include the machine envelope — otherwise a small
+  // part fits the viewport but the envelope corners sit beyond its edges
+  // and the user loses the spatial reference. Z stays on the part range so
+  // the camera doesn't zoom out unnecessarily for a shallow engraving on
+  // a machine with 200mm of Z travel.
+  if (_bounds) {
+    mnX = Math.min(mnX, _bounds.X[0]); mxX = Math.max(mxX, _bounds.X[1]);
+    mnY = Math.min(mnY, _bounds.Y[0]); mxY = Math.max(mxY, _bounds.Y[1]);
+  }
+
   // Orbit centre at bounding box centroid
   _cam.cx = (mnX + mxX) / 2;
   _cam.cy = (mnY + mxY) / 2;


### PR DESCRIPTION
## Summary

Four 3D/layout improvements bundled since they all touch the same viewer area:

**1. Executed toolpath fade (closes #28)**
Linear opacity decay over the last 100 lines (1.0 → 0.18), flat 0.18 beyond. Two-pass render keeps per-segment strokes ≤100 regardless of program size.

**2. Envelope-aware fit**
\`_fitTo3D\` unions XY with the machine envelope so the bounds box stays visible even when the part is smaller than the machine.

**3. Reset button**
\`↺ Reset\` in the viewer toolbar — restores default orbit (az=-30°, el=45°) and fits. Default initial elevation bumped 25° → 45° for a proper isometric first-load.

**4. Draggable viewer/panel splitter**
Row-resize strip between the viewer and the tab panels below. Drag to resize, double-click to reset, persisted per session via localStorage. Canvas already has a ResizeObserver so the toolpath re-renders live during drag.

All new buttons live in \`guards.js\` \`NEVER_GATE\` — always clickable.

## Test plan

- [x] Run a program — recently-executed segments render brighter than older ones, full path stays visible
- [x] 3D view always shows the machine envelope (yellow) regardless of part size
- [x] Welcome-sign program: no perceptible render lag during run
- [x] Orbit camera to upside-down, press **Reset** → snaps back to default isometric view
- [x] Reset button clickable in AUTO mode and when disconnected
- [x] Hover the splitter → row-resize cursor, accent tint
- [x] Drag splitter up → viewer shrinks, gcode listing expands
- [x] Drag splitter down → viewer expands, listing shrinks (stops at 96px minimum)
- [x] Refresh the page → viewer keeps the dragged height
- [x] Double-click the splitter → returns to default split ratio
- [x] Splitter disappears when switching to Offsets / Status tabs (viewer hidden)
- [x] Toolpath redraws at new size during/after drag
- [x] Full test suite passes (133/133)

🤖 Generated with [Claude Code](https://claude.com/claude-code)