### PR TITLE
Viewer: fix 3D envelope missing after F5 (race with config fetch)

### DIFF
--- a/frontend/js/viewer.js
+++ b/frontend/js/viewer.js
@@ -61,7 +61,14 @@ const C = {
 let _plane    = "XY";
 let _segments = [];
 let _extents  = null;   // {minU,maxU,minV,maxV} in WCS (add _wcsOffset to get machine coords)
-let _bounds   = null;   // machine limits {X:[min,max], Y:[min,max], Z:[min,max]}
+// Machine envelope. Initialised to sensible small-mill defaults so the
+// very first fit-to-content always includes the envelope — on F5 with
+// warm cache, segments can arrive before /config does, and a null
+// bounds at that point leaves the camera zoomed tight on the part,
+// pushing the envelope off-screen even after onConfig later populates
+// it. onConfig replaces these defaults with real INI values when
+// available.
+let _bounds   = { X: [0, 300], Y: [0, 200], Z: [-200, 0] };
 let _toolPos   = [0, 0, 0];  // machine coordinates (for viewer crosshair drawing)
 let _toolTrail = [];         // recent tool positions [[x,y,z], …] newest at end
 const TRAIL_MAX = 80;        // ~4 s of history at 20 Hz


### PR DESCRIPTION
Closes #36.

## Summary

On warm-cache F5, the WS state frame with `program.file` can arrive before `/config` returns, causing `_fitToContent` to run with `_bounds=null` and skip the envelope union. Camera ends up zoomed tight on the part; envelope projects off-screen. onConfig later populates `_bounds` but the re-fit guard skips because segments exist.

Fix: initialise `_bounds` with small-mill defaults at module load. First fit always includes envelope regardless of ordering. onConfig still replaces with real INI values when available.

## Test plan

- [x] Load a program, then hit F5 → envelope visible on first render (no browser restart needed)
- [x] Fresh load (new tab / full browser restart) → envelope visible as before
- [x] Reset button → fits to part + envelope, envelope in frame
- [x] Zoom in past the envelope → envelope goes off-screen (expected); Reset brings it back
- [x] Close a program (empty segments) → envelope still visible at fit

🤖 Generated with [Claude Code](https://claude.com/claude-code)